### PR TITLE
FAS-59 Fix: Ensure static files are served for admin in development.

### DIFF
--- a/fasolaki2/urls.py
+++ b/fasolaki2/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import path, include
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
@@ -29,3 +30,6 @@ urlpatterns = [
     path('', include('website.urls')),
     path('blog/', include(wagtail_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+if settings.DEBUG:
+    urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
I modified fasolaki2/urls.py to include staticfiles_urlpatterns when settings.DEBUG is True. This allows the Django development server to correctly serve static assets (CSS, JS) for the Wagtail admin panel and other apps.

This resolves an issue where CSS was not loading correctly on the /admin/ page during local development.